### PR TITLE
Update New Zealand subdivision names from Māori to English

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -3066,12 +3066,12 @@ New Zealand,NZ-NSN,Nelson City,Unitary authority,NZ
 New Zealand,NZ-NTL,Northland,Regional council,NZ
 New Zealand,NZ-OTA,Otago,Regional council,NZ
 New Zealand,NZ-S,South Island,Island,NZ
-New Zealand,NZ-STL,Murihiku,Regional council,NZ
+New Zealand,NZ-STL,Southland,Regional council,NZ
 New Zealand,NZ-TAS,Tasman District,Unitary authority,NZ
 New Zealand,NZ-TKI,Taranaki,Regional council,NZ
-New Zealand,NZ-WGN,Te Whanga-nui-a-Tara,Regional council,NZ
+New Zealand,NZ-WGN,Wellington,Regional council,NZ
 New Zealand,NZ-WKO,Waikato,Regional council,NZ
-New Zealand,NZ-WTC,Te Taihau ā uru,Regional council,NZ
+New Zealand,NZ-WTC,West Coast,Regional council,NZ
 Nicaragua,NI-AN,Atlántico Norte,Autonomous region,NI
 Nicaragua,NI-AS,Atlántico Sur,Autonomous region,NI
 Nicaragua,NI-BO,Boaco,Department,NI


### PR DESCRIPTION
Should be Southland, Wellington and West Coast.