### PR TITLE
Changed all Canadian subdivisions to english names

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -689,11 +689,11 @@ Canada,CA-BC,British Columbia,Province,CA
 Canada,CA-MB,Manitoba,Province,CA
 Canada,CA-NB,New Brunswick,Province,CA
 Canada,CA-NL,Newfoundland and Labrador,Province,CA
-Canada,CA-NS,Nouvelle-Écosse,Province,CA
+Canada,CA-NS,Nova Scotia,Province,CA
 Canada,CA-NT,Northwest Territories,Territory,CA
 Canada,CA-NU,Nunavut,Territory,CA
 Canada,CA-ON,Ontario,Province,CA
-Canada,CA-PE,Île-du-Prince-Édouard,Province,CA
+Canada,CA-PE,Prince Edward Island,Province,CA
 Canada,CA-QC,Quebec,Province,CA
 Canada,CA-SK,Saskatchewan,Province,CA
 Canada,CA-YT,Yukon,Territory,CA


### PR DESCRIPTION
Nova Scotia, and Prince Edward Island previously used the french names.