### PR TITLE
add New Providence, Bahamas

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -318,6 +318,7 @@ Bahamas,BS-MG,Mayaguana,District,BS
 Bahamas,BS-MI,Moore's Island,District,BS
 Bahamas,BS-NE,North Eleuthera,District,BS
 Bahamas,BS-NO,North Abaco,District,BS
+Bahamas,BS-NP,New Providence,Island,BS
 Bahamas,BS-NS,North Andros,District,BS
 Bahamas,BS-RC,Rum Cay,District,BS
 Bahamas,BS-RI,Ragged Island,District,BS


### PR DESCRIPTION
The capital island of the Bahamas was missing, see https://en.wikipedia.org/wiki/ISO_3166-2:BS