### PR TITLE
Added TypeScript declaration file

### DIFF
--- a/iso3166.min.d.ts
+++ b/iso3166.min.d.ts
@@ -1,0 +1,25 @@
+export as namespace iso3166;
+
+interface Subdivision {
+  type: string;
+  name: string;
+}
+interface Subdivisions {
+  [code: string]: Subdivision;
+}
+interface Country {
+  name: string;
+  sub: Subdivisions;
+}
+
+export function country(code: string): Country;
+export function subdivision(country:string, code: string): Subdivision;
+
+interface CountryMapping {
+  [code: string]: Country;
+}
+export const data: CountryMapping;
+interface CodeMapping {
+  [code: string]: string;
+}
+export const codes: CodeMapping;


### PR DESCRIPTION
Adding [declaration file](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) for the library `iso3166` based on the template [`module.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) taken from the official documentation of TypeScript 