### PR TITLE
Rename NL-FR to dutch spelling

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -3039,7 +3039,7 @@ Netherlands,NL-BQ3,Sint Eustatius,Special municipality,NL
 Netherlands,NL-CW,Curaçao,Country,NL
 Netherlands,NL-DR,Drenthe,Province,NL
 Netherlands,NL-FL,Flevoland,Province,NL
-Netherlands,NL-FR,Fryslân,Province,NL
+Netherlands,NL-FR,Friesland,Province,NL
 Netherlands,NL-GE,Gelderland,Province,NL
 Netherlands,NL-GR,Groningen,Province,NL
 Netherlands,NL-LI,Limburg,Province,NL


### PR DESCRIPTION
Use the dutch spelling instead of the West Frisian name, https://en.wikipedia.org/wiki/Friesland